### PR TITLE
Update Chef-Sentry cookbook to support Sentry 8.6.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,10 +28,19 @@ default["sentry"]["plugins"] = [
   ["django-bcrypt", "0.9.2"],
   ["django-sendmail-backend", "0.1.2"],
 ]
+# dependencies per: https://docs.getsentry.com/on-premise/server/installation/python/
 default["sentry"]["dependency"]["packages"] = [
+  "python-setuptools",
+  "python-pip",
+  "python-dev",
+  "gcc"
+  "libjpeg-dev",
   "libxml2-dev",
+  "libxslt-dev",
   "libxslt1-dev",
   "libffi-dev",
+  "libyaml-dev",
+  "libpq-dev", # not listed but blocks sentry install
 ]
 default["sentry"]["install_dir"] = "/opt/sentry"
 default["sentry"]["filestore_dir"] = "/opt/sentry/data"
@@ -44,6 +53,8 @@ default["sentry"]["env_path"] = "#{node["sentry"]["env_d_path"]}/env"
 default["sentry"]["config"]["db_engine"] = "django.db.backends.postgresql_psycopg2"
 default["sentry"]["config"]["db_options"] = {autocommit: true}
 default["sentry"]["config"]["admin_email"] = ""
+
+# web server
 default["sentry"]["config"]["allow_registration"] = false
 default["sentry"]["config"]["beacon"] = false
 default["sentry"]["config"]["public"] = false
@@ -57,18 +68,30 @@ default["sentry"]["config"]["web_options"] = {
   }
 }
 default["sentry"]["config"]["url_prefix"] = "http://localhost:#{node["sentry"]["config"]["web_port"]}"
+
+# smtp
+default["sentry"]["config"]["smtp_host"] = '0.0.0.0'
+default["sentry"]["config"]["smtp_port"] = '1025'
+default["sentry"]["config"]["smtp_hostname"] = 'localhost'  
+
 default["sentry"]["config"]["email_default_from"] = "#{node["sentry"]["user"]}@#{node[:fqdn]}"
 default["sentry"]["config"]["email_backend"] = "django.core.mail.backends.smtp.EmailBackend"
 default["sentry"]["config"]["email_host"] = "localhost"
 default["sentry"]["config"]["email_port"] = "25"
 default["sentry"]["config"]["email_use_tls"] = false
 default["sentry"]["config"]["email_subject_prefix"] = nil
+default["sentry"]["config"]["email_list_namespace"] = "localhost"
+default["sentry"]["config"]["email_enable_replies"] = false
 default["sentry"]["config"]["additional_apps"] = ["djangosecure", "django_bcrypt"]
 default["sentry"]["config"]["prepend_middleware_classes"] = ["djangosecure.middleware.SecurityMiddleware"]
 default["sentry"]["config"]["append_middleware_classes"] = []
+# general
 default["sentry"]["config"]["use_big_ints"] = true
+default["sentry"]["config"]["single_organization"] = true
+default["sentry"]["config"]["debug"] = false
 # Redis config
 default["sentry"]["config"]["redis_enabled"] = true
+default["sentry"]["config"]["redis_config"]["hosts"][0]["name"] = "default"
 default["sentry"]["config"]["redis_config"]["hosts"][0]["host"] = "127.0.0.1"
 default["sentry"]["config"]["redis_config"]["hosts"][0]["port"] = "6379"
 # Cache config
@@ -79,7 +102,8 @@ default["sentry"]["config"]["broker_url"] = "redis://localhost:6379"
 default["sentry"]["config"]["celeryd_concurrency"] = 1
 default["sentry"]["config"]["celery_send_events"] = false
 default["sentry"]["config"]["celerybeat_schedule_filename"] = "#{default["sentry"]["filestore_dir"]}/celery_beat_schedule"
-
+#digests config
+default["sentry"]["config"]["digests"] = 'sentry.digests.backends.redis.RedisBackend'
 default["sentry"]["config"]["ratelimiter"] = "sentry.ratelimits.redis.RedisRateLimiter"
 default["sentry"]["config"]["buffer"] = "sentry.buffer.redis.RedisBuffer"
 default["sentry"]["config"]["quotas"] = "sentry.quotas.redis.RedisQuota"
@@ -87,6 +111,8 @@ default["sentry"]["config"]["tsdb"] = "sentry.tsdb.redis.RedisTSDB"
 # Filestore config
 default["sentry"]["config"]["filestore"] = "django.core.files.storage.FileSystemStorage"
 default["sentry"]["config"]["filestore_options"]["location"] = default["sentry"]["filestore_dir"]
+# data sampling
+default["sentry"]["config"]["sample_data"] = false
 
 default["sentry"]["data_bag"] = "sentry"
 default["sentry"]["data_bag_item"] = "credentials"

--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -78,55 +78,143 @@ directory node["sentry"]["config_dir"] do
   action :create
 end
 
-template node["sentry"]["config_file_path"] do
-  source "sentry.conf.py.erb"
-  owner sentry_user
-  group sentry_group
-  mode "750"
-  variables({
-    db_engine: node["sentry"]["config"]["db_engine"],
-    db_name: sentry_config["database_name"],
-    db_user: sentry_config["database_user"],
-    db_password: sentry_config["database_password"],
-    db_host: sentry_config["database_host"],
-    db_port: sentry_config["database_port"],
-    db_options: node["sentry"]["config"]["db_options"],
-    admin_email: node["sentry"]["config"]["admin_email"],
-    signing_token: sentry_config["signing_token"],
-    public: node["sentry"]["config"]["public"],
-    allow_registration: node["sentry"]["config"]["allow_registration"],
-    beacon: node["sentry"]["config"]["beacon"],
-    url_prefix: node["sentry"]["config"]["url_prefix"].sub(/(\/)+\z/, ""),
-    web_host: node["sentry"]["config"]["web_host"],
-    web_port: node["sentry"]["config"]["web_port"],
-    web_options: node["sentry"]["config"]["web_options"],
-    secure_proxy_ssl_header: node["sentry"]["config"]["secure_proxy_ssl_header"],
-    email_default_from: node["sentry"]["config"]["email_default_from"],
-    email_backend: node["sentry"]["config"]["email_backend"],
-    email_host: node["sentry"]["config"]["email_host"],
-    email_port: node["sentry"]["config"]["email_port"],
-    email_user: sentry_config["email_host_user"],
-    email_password: sentry_config["email_host_password"],
-    email_use_tls: node["sentry"]["config"]["email_use_tls"],
-    email_subject_prefix: node["sentry"]["config"]["email_subject_prefix"],
-    additional_apps: Array(node["sentry"]["config"]["additional_apps"]),
-    prepend_middleware_classes: Array(node["sentry"]["config"]["prepend_middleware_classes"]),
-    append_middleware_classes: Array(node["sentry"]["config"]["append_middleware_classes"]),
-    redis_enabled: node["sentry"]["config"]["redis_enabled"],
-    redis_config: node["sentry"]["config"]["redis_config"],
-    cache: node["sentry"]["config"]["cache"],
-    celery_always_eager: node["sentry"]["config"]["celery_always_eager"],
-    broker_url: node["sentry"]["config"]["broker_url"],
-    celeryd_concurrency: node["sentry"]["config"]["celeryd_concurrency"],
-    celery_send_events: node["sentry"]["config"]["celery_send_events"],
-    celerybeat_schedule_filename: node["sentry"]["config"]["celerybeat_schedule_filename"],
-    ratelimiter: node["sentry"]["config"]["ratelimiter"],
-    buffer: node["sentry"]["config"]["buffer"],
-    quotas: node["sentry"]["config"]["quotas"],
-    tsdb: node["sentry"]["config"]["tsdb"],
-    filestore: node["sentry"]["config"]["filestore"],
-    filestore_options: node["sentry"]["config"]["filestore_options"],
-  })
+# redis and email configs move to conifg.yml in 8
+if node["sentry"]["version"].split(".")[0].to_i < 8
+  template node["sentry"]["config_file_path"] do
+    source "sentry.conf.py.erb"
+    owner sentry_user
+    group sentry_group
+    mode "750"
+
+    variables({
+      db_engine: node["sentry"]["config"]["db_engine"],
+      db_name: sentry_config["database_name"],
+      db_user: sentry_config["database_user"],
+      db_password: sentry_config["database_password"],
+      db_host: sentry_config["database_host"],
+      db_port: sentry_config["database_port"],
+      db_options: node["sentry"]["config"]["db_options"],
+      admin_email: node["sentry"]["config"]["admin_email"],
+      signing_token: sentry_config["signing_token"],
+      public: node["sentry"]["config"]["public"],
+      allow_registration: node["sentry"]["config"]["allow_registration"],
+      beacon: node["sentry"]["config"]["beacon"],
+      url_prefix: node["sentry"]["config"]["url_prefix"].sub(/(\/)+\z/, ""),
+      web_host: node["sentry"]["config"]["web_host"],
+      web_port: node["sentry"]["config"]["web_port"],
+      web_options: node["sentry"]["config"]["web_options"],
+      secure_proxy_ssl_header: node["sentry"]["config"]["secure_proxy_ssl_header"],
+      email_default_from: node["sentry"]["config"]["email_default_from"],
+      email_backend: node["sentry"]["config"]["email_backend"],
+      email_host: node["sentry"]["config"]["email_host"],
+      email_port: node["sentry"]["config"]["email_port"],
+      email_user: sentry_config["email_host_user"],
+      email_password: sentry_config["email_host_password"],
+      email_use_tls: node["sentry"]["config"]["email_use_tls"],
+      email_subject_prefix: node["sentry"]["config"]["email_subject_prefix"],
+      additional_apps: Array(node["sentry"]["config"]["additional_apps"]),
+      prepend_middleware_classes: Array(node["sentry"]["config"]["prepend_middleware_classes"]),
+      append_middleware_classes: Array(node["sentry"]["config"]["append_middleware_classes"]),
+      redis_enabled: node["sentry"]["config"]["redis_enabled"],
+      redis_config: node["sentry"]["config"]["redis_config"],
+      cache: node["sentry"]["config"]["cache"],
+      celery_always_eager: node["sentry"]["config"]["celery_always_eager"],
+      broker_url: node["sentry"]["config"]["broker_url"],
+      celeryd_concurrency: node["sentry"]["config"]["celeryd_concurrency"],
+      celery_send_events: node["sentry"]["config"]["celery_send_events"],
+      celerybeat_schedule_filename: node["sentry"]["config"]["celerybeat_schedule_filename"],
+      ratelimiter: node["sentry"]["config"]["ratelimiter"],
+      buffer: node["sentry"]["config"]["buffer"],
+      quotas: node["sentry"]["config"]["quotas"],
+      tsdb: node["sentry"]["config"]["tsdb"],
+      filestore: node["sentry"]["config"]["filestore"],
+      filestore_options: node["sentry"]["config"]["filestore_options"],
+    })
+  end
+else # 8.0 or above
+  template node["sentry"]["config_file_path"] do
+    source ["sentry.conf.8.0.py.erb"]
+    owner sentry_user
+    group sentry_group
+    mode "750"
+    variables({
+      # db
+      db_engine: node["sentry"]["config"]["db_engine"],
+      db_name: sentry_config["database_name"],
+      db_user: sentry_config["database_user"],
+      db_password: sentry_config["database_password"],
+      db_host: sentry_config["database_host"],
+      db_port: sentry_config["database_port"],
+      db_options: node["sentry"]["config"]["db_options"],
+
+      # general
+      single_organization: node["sentry"]["config"]["single_organization"],
+      debug: node["sentry"]["config"]["debug"],
+      
+      # authentication
+      signing_token: sentry_config["signing_token"],
+      public: node["sentry"]["config"]["public"],
+      allow_registration: node["sentry"]["config"]["allow_registration"],
+      allow_origin: node["sentry"]["config"]["allow_origin"], #new
+      beacon: node["sentry"]["config"]["beacon"],
+      # web server
+      web_host: node["sentry"]["config"]["web_host"],
+      web_port: node["sentry"]["config"]["web_port"],
+      web_options: node["sentry"]["config"]["web_options"],
+      secure_proxy_ssl_header: node["sentry"]["config"]["secure_proxy_ssl_header"],
+      session_cookie_secure: node["sentry"]["config"]["session_cookie_secure"],
+      csrf_cookie_secure: node["sentry"]["config"]["csrf_cookie_secure"],
+      force_script_name: node["sentry"]["config"]["force_script_name"],
+      # smtp
+      smtp_host: node["sentry"]["config"]["smtp_host"],
+      smtp_port: node["sentry"]["config"]["smtp_port"],
+      smtp_hostname: node["sentry"]["config"]["smtp_hostname"],
+
+      additional_apps: Array(node["sentry"]["config"]["additional_apps"]),
+      prepend_middleware_classes: Array(node["sentry"]["config"]["prepend_middleware_classes"]),
+      append_middleware_classes: Array(node["sentry"]["config"]["append_middleware_classes"]),
+      cache: node["sentry"]["config"]["cache"],
+      sample_data: node["sentry"]["config"]["sample_data"],
+      # celery
+      broker_url: node["sentry"]["config"]["broker_url"],
+      # digests
+      digests: node["sentry"]["config"]["digests"],
+      ratelimiter: node["sentry"]["config"]["ratelimiter"],
+      buffer: node["sentry"]["config"]["buffer"],
+      quotas: node["sentry"]["config"]["quotas"],
+      tsdb: node["sentry"]["config"]["tsdb"],
+      filestore: node["sentry"]["config"]["filestore"],
+      filestore_options: node["sentry"]["config"]["filestore_options"],
+    })
+  end
+
+  template node["sentry"]["config_file_path"] do 
+    source "conf.yml.erb"
+    owner sentry_user
+    group sentry_group
+    mode "750"
+    variables({
+      # email
+      email_default_from: node["sentry"]["config"]["email_default_from"],
+      email_host: node["sentry"]["email_host"],
+      email_port: node["sentry"]["config"]["email_port"],
+      email_user: sentry_config["email_host_user"],
+      email_password: sentry_config["email_host_password"],
+      email_use_tls: node["sentry"]["config"]["email_use_tls"],
+      email_backend: node["sentry"]["config"]["email_backend"], 
+      email_enable_replies: node["sentry"]["config"]["email_enable_replies"],
+      email_reply_hostname: node["sentry"]["config"]["email_reply_hostname"],
+      mailgun_api_key: sentry_config["mailgun_api_key"],
+      # redis
+      redis_enabled: node["sentry"]["config"]["redis_enabled"],
+      redis_config: node["sentry"]["config"]["redis_config"],
+      # general configs
+      admin_email: node["sentry"]["config"]["admin_email"],
+      url_prefix: node["sentry"]["config"]["url_prefix"].sub(/(\/)+\z/, ""),
+      # sentry secret: regen if compromised
+      sentry_secret_key: sentry_config["sentry_secret_key"],
+    })
+  end
 end
 
 execute "sentry DB upgrade" do
@@ -140,12 +228,12 @@ initial_admin_json = "#{node["sentry"]["config_dir"]}/initial_admin.json"
 initial_admin_config = {}
 
 if node["sentry"]["version"].split(".")[0].to_i < 8
-  # In sentry version prior to 8 the user table model is having field first_name and last_name
+  # In sentry version prior to 8 the user table model has the fields 'first_name' and 'last_name'
   initial_admin_config["first_name"] = sentry_config["admin_first_name"]
   initial_admin_config["last_name"] = sentry_config["admin_last_name"]
   create_initial_admin_command = "#{node["sentry"]["install_dir"]}/bin/sentry --config=#{node["sentry"]["config_file_path"]} loaddata #{initial_admin_json}"
 else
-  # In sentry version 8 the user table model is having field name
+  # In sentry version 8 the user table model has the field 'name'
   initial_admin_config["name"] = "#{sentry_config['admin_first_name']} #{sentry_config['admin_last_name']}"
   create_initial_admin_command = "#{node["sentry"]["install_dir"]}/bin/sentry --config=#{node["sentry"]["config_file_path"]} django loaddata #{initial_admin_json}"
 end

--- a/templates/default/conf.yml.erb
+++ b/templates/default/conf.yml.erb
@@ -1,0 +1,61 @@
+# While a lot of configuration in Sentry can be changed via the UI, for all
+# new-style config (as of 8.0) you can also declare values here in this file
+# to enforce defaults or to ensure they cannot be changed via the UI. For more
+# information see the Sentry documentation.
+
+###############
+# Mail Server #
+###############
+
+mail.backend: <%= @mail_backend %>  # Use dummy if you want to disable email entirely
+mail.host: '<%= @email_host %>'
+mail.port: '<%= @email_port %>'
+mail.username: '<%= @email_user || '' %>'
+mail.password: '<%= @email_password || '' %>'
+mail.use-tls: <%= @email_use_tls ? true : false %>
+# The email address to send on behalf of
+mail.from: '<%= @email_default_from %>' 
+
+# If you'd like to configure email replies, enable this.
+<% if @email_enable_replies %>
+mail.enable-replies: true
+<% else %>
+# mail.enable-replies: false
+<% end %>
+
+# When email-replies are enabled, this value is used in the Reply-To header
+<% if @email_reply_hostname %>
+mail.reply-hostname: '<%= @email_reply_hostname %>'
+<% else %>
+# mail.reply-hostname: ''
+<% end %>
+
+# If you're using mailgun for inbound mail, set your API key and configure a
+# route to forward to /api/hooks/mailgun/inbound/
+<% if @mailgun_api_key %>
+mail.mailgun-api-key: '<%= mailgun_api_key %>'
+<% else %>
+# mail.mailgun-api-key: ''
+<% end %>
+
+###################
+# System Settings #
+###################
+
+# If this file ever becomes compromised, it's important to regenerate your a new key
+# Changing this value will result in all current sessions being invalidated.
+# A new key can be generated with `$ sentry config generate-secret-key`
+system.secret-key: '<%= @sentry_secret_key %>'
+
+# The ``redis.clusters`` setting is used, unsurprisingly, to configure Redis
+# clusters. These clusters can be then referred to by name when configuring
+# backends such as the cache, digests, or TSDB backend.
+redis.clusters:
+  <% @redis_config["hosts"].each_with_index do |(key, hash), index | %>
+  <%= hash[:name] %>:
+    hosts:
+      <%= index %>:
+        <%= hash[:host] %>
+        <%= hash[:port] %>
+        <%= hash[:password] if hash[:password] %>
+  <% end %>

--- a/templates/default/sentry.conf.8.0.py.erb
+++ b/templates/default/sentry.conf.8.0.py.erb
@@ -1,0 +1,205 @@
+# This file is just Python, with a touch of Django which means
+# you can inherit and tweak settings to your hearts content.
+from sentry.conf.server import *
+
+import os.path
+
+CONF_ROOT = os.path.dirname(__file__)
+
+DATABASES = {
+    'default': {
+        'ENGINE': '<%= @db_engine %>',
+        'NAME': '<%= @db_name %>',
+        'USER': '<%= @db_user %>',
+        'PASSWORD': '<%= @db_password %>',
+        'HOST': '<%= @db_host %>',
+        'PORT': '<%= @db_port %>',
+        'AUTOCOMMIT': <%= @db_options[:autocommit] ? 'True' : 'None' %>,
+        'ATOMIC_REQUESTS': <%= @db_options[:atomic_requests] ? 'True' : 'None' %>,
+    }
+}
+
+# You should not change this setting after your database has been created
+# unless you have altered all schemas first
+SENTRY_USE_BIG_INTS = <%= @use_big_ints ? 'True' : 'False' %>
+
+# If you're expecting any kind of real traffic on Sentry, we highly recommend
+# configuring the CACHES and Redis settings
+
+###########
+# General #
+###########
+
+# Instruct Sentry that this install intends to be run by a single organization
+# and thus various UI optimizations should be enabled.
+SENTRY_SINGLE_ORGANIZATION = <%= @single_organization ? 'True' : 'False' %>
+DEBUG = <%= @debug ? 'True' : 'False' %>
+
+###########
+## Cache ##
+###########
+
+# Sentry currently utilizes two separate mechanisms. While CACHES is not a
+# requirement, it will optimize several high throughput patterns.
+
+# If you wish to use memcached, install the dependencies and adjust the config
+# as shown:
+#
+#   pip install python-memcached
+#
+# CACHES = {
+#     'default': {
+#         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+#         'LOCATION': ['127.0.0.1:11211'],
+#     }
+# }
+
+# A primary cache is required for things such as processing events
+SENTRY_CACHE = '<%= @cache %>'
+
+###########
+## Queue ##
+###########
+
+# See https://docs.getsentry.com/on-premise/server/queue/ for more
+# information on configuring your queue broker and workers. Sentry relies
+# on a Python framework called Celery to manage queues.
+
+BROKER_URL = '<%= @broker_url %>'
+
+#################
+## Rate Limits ##
+#################
+
+# Rate limits apply to notification handlers and are enforced per-project
+# automatically.
+
+SENTRY_RATELIMITER = '<%= @ratelimiter %>'
+
+####################
+## Update Buffers ##
+####################
+
+# Buffers (combined with queueing) act as an intermediate layer between the
+# database and the storage API. They will greatly improve efficiency on large
+# numbers of the same events being sent to the API in a short amount of time.
+# (read: if you send any kind of real data to Sentry, you should enable buffers)
+
+SENTRY_BUFFER = '<%= @buffer %>'
+
+############
+## Quotas ##
+############
+
+# Quotas allow you to rate limit individual projects or the Sentry install as
+# a whole.
+
+SENTRY_QUOTAS = '<%= @quotas %>'
+
+##########
+## TSDB ##
+##########
+
+# The TSDB is used for building charts as well as making things like per-rate
+# alerts possible.
+
+SENTRY_TSDB = '<%= @tsdb %>'
+
+###########
+# Digests #
+###########
+
+# The digest backend powers notification summaries.
+
+SENTRY_DIGESTS = '<%= @digests %>'
+
+##################
+## File storage ##
+##################
+
+# Any Django storage backend is compatible with Sentry. For more solutions see
+# the django-storages package: https://django-storages.readthedocs.org/en/latest/
+
+SENTRY_FILESTORE = '<%= @filestore %>'
+SENTRY_FILESTORE_OPTIONS = <%= python_hash_string @filestore_options %>
+
+################
+## Web Server ##
+################
+
+# If you're using a reverse SSL proxy, you should enable the X-Forwarded-Proto
+# header and uncomment the following settings
+<% if @secure_proxy_ssl_header %>
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+<% else %>
+# SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+# SESSION_COOKIE_SECURE = True
+# CSRF_COOKIE_SECURE = True
+<% end %>
+
+# If you're not hosting at the root of your web server,
+# you need to uncomment and set it to the path where Sentry is hosted.
+<% if @force_script -%>
+FORCE_SCRIPT_NAME = '<%= @forces_script_name %>'
+<% else %>
+# FORCE_SCRIPT_NAME = '/sentry'
+<% end -%>
+
+SENTRY_WEB_HOST = '<%= @web_host %>'
+SENTRY_WEB_PORT = <%= @web_port %>
+SENTRY_WEB_OPTIONS = <%= python_hash_string @web_options %>
+
+###################
+## Other options ##
+###################
+
+##########
+## Auth ##
+##########
+
+SENTRY_PUBLIC = <%= @public ? 'True' : 'False' %>
+SENTRY_ALLOW_ORIGIN = <%= @allow_origin ? 'True' : 'False' %>
+SENTRY_FEATURES['auth:register'] = <%= @allow_registration ? 'True' : 'False' %>
+
+#################
+## SMTP SERVER ##
+#################
+
+<% if @sentry_smtp_host -%>
+SENTRY_SMTP_HOST: '<%= @smtp_host %>'
+SENTRY_SMTP_PORT: '<%= @smtp_port %>'
+SENTRY_SMTP_HOSTNAME: '<%= @smtp_hostname %>'
+<% end -%>
+
+###################
+## DATA SAMPLING ##
+###################
+
+<% if @sample_data -%>
+SENTRY_SAMPLE_DATA = True
+<% end %>
+
+SENTRY_BEACON = <%= @beacon ? 'True' : 'False' %>
+SENTRY_ADMIN_EMAIL = '<%= @admin_email %>'
+SENTRY_KEY = '<%= @signing_token %>'
+
+
+<% if @additional_apps.any? -%>
+INSTALLED_APPS = INSTALLED_APPS + (
+  <%= @additional_apps.map{|app| "'#{app}'"}.join ",\n  "%>,
+)
+<% end %>
+
+<% if @prepend_middleware_classes.any? -%>
+MIDDLEWARE_CLASSES = (
+  <%= @prepend_middleware_classes.map{|middleware| "'#{middleware}'"}.join ",\n  " %>,
+) + MIDDLEWARE_CLASSES
+<% end -%>
+<% if @append_middleware_classes.any? -%>
+
+MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + (
+  <%= @append_middleware_classes.map{|middleware| "'#{middleware}'"}.join ",\n  " %>,
+)
+<% end -%>


### PR DESCRIPTION
- templates
add sentry.conf.8.0.py.erb template with structure accomodating to properties
present in the generated sentry.conf.py file in 8.6
add conf.yml file to conform to 8.x Sentry standards of splitting configs
out from sentry.conf.py to conf.yml

- attributes
update attributes/default.rb to contain default values for new properties in
sentry.conf.py and conf.yml

- recipes
update _configure.rb to check for Sentry version and use new templates if
version > 8